### PR TITLE
Fix rubygem incompatibility errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 Flexible project management Web application
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://www.redmine.org)
-[![Version: 6.1.0~ynh1](https://img.shields.io/badge/Version-6.1.0~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/redmine/)
+[![Version: 6.1.1~ynh1](https://img.shields.io/badge/Version-6.1.1~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/redmine/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/redmine"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Redmine"
 description.en = "Flexible project management Web application"
 description.fr = "Gestionnaire de projet flexible sous forme d'application Web"
 
-version = "6.1.0~ynh1"
+version = "6.1.1~ynh1"
 
 maintainers = []
 
@@ -39,8 +39,8 @@ ram.runtime = "50M"
 
 [resources]
     [resources.sources.main]
-    url = "https://github.com/redmine/redmine/archive/refs/tags/6.1.0.tar.gz"
-    sha256 = "ecdbf63eeb7fe09e43a0bf251d708d9b93c91d301b892a3f1b4ef5f3d3ceeaa4"
+    url = "https://github.com/redmine/redmine/archive/refs/tags/6.1.1.tar.gz"
+    sha256 = "a5736579e7c3e64e7ef1453d0a07e247d7c7302e24994001c80f38f797f6c6fd"
     autoupdate.strategy = "latest_github_tag"
 
     [resources.system_user]

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -9,7 +9,6 @@ _redmine_ruby_install() {
         gem update --system 3.4.22 --no-document
         gem install bundler passenger --no-document
         bundle config set --local without 'development test rmagick'
-        bundle add 'webrick' --version '~> 1.7'
         bundle install
     popd
 }

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -6,7 +6,7 @@
 
 _redmine_ruby_install() {
     pushd "$install_dir"
-        gem update --system --no-document
+        gem update --system 3.4.7 --no-document
         gem install bundler passenger --no-document
         bundle config set --local without 'development test rmagick'
         bundle add 'webrick' --version '~> 1.7'

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -6,8 +6,8 @@
 
 _redmine_ruby_install() {
     pushd "$install_dir"
-#        gem update --system 3.4.7 --no-document
-#        gem install bundler passenger --no-document
+        gem update --system 3.4.22 --no-document
+        gem install bundler passenger --no-document
         bundle config set --local without 'development test rmagick'
         bundle add 'webrick' --version '~> 1.7'
         bundle install

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -6,8 +6,8 @@
 
 _redmine_ruby_install() {
     pushd "$install_dir"
-        gem update --system 3.4.7 --no-document
-        gem install bundler passenger --no-document
+#        gem update --system 3.4.7 --no-document
+#        gem install bundler passenger --no-document
         bundle config set --local without 'development test rmagick'
         bundle add 'webrick' --version '~> 1.7'
         bundle install

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -22,7 +22,7 @@ ynh_config_change_url_nginx
 #=================================================
 ynh_script_progression "Starting $app's systemd service..."
 
-ynh_systemctl --service="$app" --action="start"  --wait_until="WEBrick::HTTPServer#start"
+ynh_systemctl --service="$app" --action="start"  --wait_until="Listening on http" --timeout=300
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/install
+++ b/scripts/install
@@ -29,6 +29,7 @@ ynh_script_progression "Adding extra dependencies..."
 # We should add extra gems to the Gemfile.local file according to the Redmine installation docs.
 cat <<EOF > "$install_dir/Gemfile.local"
 gem 'ostruct'
+gem 'puma'
 EOF
 
 #=================================================
@@ -76,7 +77,7 @@ chown -R "$app:$app" "$install_dir"
 #=================================================
 ynh_script_progression "Starting $app's systemd service..."
 
-ynh_systemctl --service="$app" --action="start" --wait_until="Listening on http"
+ynh_systemctl --service="$app" --action="start" --wait_until="Listening on http" --timeout=300
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/install
+++ b/scripts/install
@@ -21,8 +21,9 @@ ynh_config_add --template="database.example.yml" --destination="$install_dir/con
 
 ynh_config_add --template="configuration.yml.example" --destination="$install_dir/config/configuration.yml"
 
-# fix : You can add ostruct to your Gemfile or gemspec to silence this warning. 
-echo "gem 'ostruct'" > "$install_dir/Gemfile"
+# fix : You can add ostruct to your Gemfile or gemspec to silence this warning.
+# fix 2: Add ostruct to Gemfile in append mode.
+echo "gem 'ostruct'" >> "$install_dir/Gemfile"
 
 #=================================================
 # BUILD APP

--- a/scripts/install
+++ b/scripts/install
@@ -29,7 +29,6 @@ ynh_script_progression "Adding extra dependencies..."
 # We should add extra gems to the Gemfile.local file according to the Redmine installation docs.
 cat <<EOF > "$install_dir/Gemfile.local"
 gem 'ostruct'
-gem 'puma'
 EOF
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -21,9 +21,16 @@ ynh_config_add --template="database.example.yml" --destination="$install_dir/con
 
 ynh_config_add --template="configuration.yml.example" --destination="$install_dir/config/configuration.yml"
 
-# fix : You can add ostruct to your Gemfile or gemspec to silence this warning.
-# fix 2: Add ostruct to Gemfile in append mode.
-echo "gem 'ostruct'" >> "$install_dir/Gemfile"
+#=================================================
+# ADDING EXTRA GEMS (Puma & Ostruct)
+#=================================================
+ynh_script_progression "Adding extra dependencies..."
+
+# We should add extra gems to the Gemfile.local file according to the Redmine installation docs.
+cat <<EOF > "$install_dir/Gemfile.local"
+gem 'ostruct'
+gem 'puma'
+EOF
 
 #=================================================
 # BUILD APP

--- a/scripts/install
+++ b/scripts/install
@@ -77,7 +77,7 @@ chown -R "$app:$app" "$install_dir"
 #=================================================
 ynh_script_progression "Starting $app's systemd service..."
 
-ynh_systemctl --service="$app" --action="start" --wait_until="WEBrick::HTTPServer#start"
+ynh_systemctl --service="$app" --action="start" --wait_until="Listening on http"
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/install
+++ b/scripts/install
@@ -21,6 +21,9 @@ ynh_config_add --template="database.example.yml" --destination="$install_dir/con
 
 ynh_config_add --template="configuration.yml.example" --destination="$install_dir/config/configuration.yml"
 
+# fix : You can add ostruct to your Gemfile or gemspec to silence this warning. 
+echo "gem 'ostruct'" > "$install_dir/Gemfile"
+
 #=================================================
 # BUILD APP
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -61,7 +61,7 @@ chown -R "$app:$app" "$install_dir"
 #=================================================
 ynh_script_progression "Reloading NGINX web server and $app's service..."
 
-ynh_systemctl --service="$app" --action="start" --wait_until="WEBrick::HTTPServer#start"
+ynh_systemctl --service="$app" --action="start" --wait_until="Listening on http" --timeout=300
 
 ynh_systemctl --service=nginx --action=reload
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -63,7 +63,7 @@ ynh_config_add_logrotate
 #=================================================
 ynh_script_progression "Starting $app's systemd service..."
 
-ynh_systemctl --service="$app" --action="start" --wait_until="WEBrick::HTTPServer#start"
+ynh_systemctl --service="$app" --action="start" --wait_until="Listening on http" --timeout=300
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -22,6 +22,17 @@ mkdir -p "$install_dir/log" "$install_dir/tmp" "$install_dir/public/plugin_asset
 chmod 750 "$install_dir/log" "$install_dir/tmp" "$install_dir/public/plugin_assets"
 
 #=================================================
+# ADDING EXTRA GEMS (Puma & Ostruct)
+#=================================================
+ynh_script_progression "Adding extra dependencies..."
+
+# We should add extra gems to the Gemfile.local file according to the Redmine installation docs.
+cat <<EOF > "$install_dir/Gemfile.local"
+gem 'ostruct'
+gem 'puma'
+EOF
+
+#=================================================
 # BUILD APP
 #=================================================
 ynh_script_progression "Building $app..."

--- a/tests.toml
+++ b/tests.toml
@@ -16,4 +16,3 @@ test_format = 1.0
     # Commits to test upgrade from
     # -------------------------------
 
-    test_upgrade_from.8483471e72dbda6de922cc3dd21ca7aaf5da9911.name = "Upgrade from 6.0.3~ynh2"


### PR DESCRIPTION
## Problem

- This PR is for resolving issue #55, a rubygems incompatibility problem that occurs at the installation phase.

## Solution

- The solution is to install a specific version of ruby gems instead of the latest one which is incompatible.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
